### PR TITLE
Add test checking that the snap is running as expected

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   main-snap:
-    uses: ubuntu-robotics/snap_workflows/.github/workflows/build-install-test-snap.yaml@F_add_custom_script
+    uses: ubuntu-robotics/snap_workflows/.github/workflows/build-install-test-snap.yaml@main
     with:
       branch-name: main
       snap-name: ros2-talker-listener

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -18,7 +18,7 @@ jobs:
       snap-name: ros2-talker-listener
       test-script: "#!/bin/bash
 
-snap install ros2-cli --channel=foxy/beta
+sudo snap install ros2-cli --channel=foxy/beta
 
 check_node() {
     local node_name=$1
@@ -26,7 +26,7 @@ check_node() {
     if [ $? -eq 0 ]; then
         echo \"$node_name is running.\"
     else
-        echo \"Error: $node_name is not running.\"
+        echo \"Error - $node_name is not running.\"
         exit 1
     fi
 }
@@ -39,7 +39,7 @@ check_topic() {
     if [ \"$pub_count\" -gt 0 ] && [ \"$sub_count\" -gt 0 ]; then
         echo \"$topic_name has publishers and subscribers.\"
     else
-        echo \"Error: $topic_name has no publishers or subscribers.\"
+        echo \"Error - $topic_name has no publishers or subscribers.\"
         exit 1
     fi
 }

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,7 +20,6 @@ jobs:
       test-script: |
                     #!/bin/bash
                     sudo snap install ros2-cli --channel=foxy/beta
-                    wait
 
                     check_node() {
                         local node_name=$1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -43,9 +43,11 @@ jobs:
                         fi
                     }
 
-                    timeout 5s ros2-talker-listener &
-                    check_node listener &
-                    check_node talker &
+                    ros2-talker-listener &
+                    pid=$!
+                    check_node talker
+                    check_node listener
                     check_topic chatter
-                    wait
+                    kill $pid
+
                     echo "All checks passed successfully."

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -18,9 +18,11 @@ jobs:
       snap-name: ros2-talker-listener
       test-script: "#!/bin/bash
 
+snap install ros2-cli --channel=foxy/beta
+
 check_node() {
     local node_name=$1
-    ros2 node list | grep -q \"/$node_name\"
+    ros2-cli.ros2 node list | grep -q \"/$node_name\"
     if [ $? -eq 0 ]; then
         echo \"$node_name is running.\"
     else
@@ -31,8 +33,8 @@ check_node() {
 
 check_topic() {
     local topic_name=$1
-    local pub_count=$(ros2 topic info /$topic_name | grep \"Publisher count:\" | awk '{print $3}')
-    local sub_count=$(ros2 topic info /$topic_name | grep \"Subscription count:\" | awk '{print $3}')
+    local pub_count=$(ros2-cli.ros2 topic info /$topic_name | grep \"Publisher count:\" | awk '{print $3}')
+    local sub_count=$(ros2-cli.ros2 topic info /$topic_name | grep \"Subscription count:\" | awk '{print $3}')
 
     if [ \"$pub_count\" -gt 0 ] && [ \"$sub_count\" -gt 0 ]; then
         echo \"$topic_name has publishers and subscribers.\"

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -28,6 +28,7 @@ jobs:
                             echo "$node_name is running."
                         else
                             echo "Error - $node_name is not running."
+                            kill $pid
                             exit 1
                         fi
                     }
@@ -39,6 +40,7 @@ jobs:
                             echo "$topic_name has publishers and subscribers."
                         else
                             echo "Error - $topic_name has no publishers or subscribers."
+                            kill $pid
                             exit 1
                         fi
                     }

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -17,35 +17,35 @@ jobs:
       branch-name: main
       snap-name: ros2-talker-listener
       test-script: |
-                    #!/bin/bash\n
-                    sudo snap install ros2-cli --channel=foxy/beta\n
-                    wait\n
+                    #!/bin/bash
+                    sudo snap install ros2-cli --channel=foxy/beta
+                    wait
 
-                    check_node() {\n
-                        local node_name=$1\n
-                        ros2-cli.ros2 node list | grep -q "/$node_name"\n
-                        if [ $? -eq 0 ]; then\n
-                            echo "$node_name is running."\n
-                        else\n
-                            echo "Error - $node_name is not running."\n
-                            exit 1\n
-                        fi\n
-                    }\n
-                    check_topic() {\n
-                        local topic_name=$1\n
-                        local pub_count=$(ros2-cli.ros2 topic info /$topic_name | grep "Publisher count:" | awk '{print $3}')\n
-                        local sub_count=$(ros2-cli.ros2 topic info /$topic_name | grep "Subscription count:" | awk '{print $3}')\n
-                        if [ "$pub_count" -gt 0 ] && [ "$sub_count" -gt 0 ]; then\n
-                            echo "$topic_name has publishers and subscribers."\n
-                        else\n
-                            echo "Error - $topic_name has no publishers or subscribers."\n
-                            exit 1\n
-                        fi\n
-                    }\n
+                    check_node() {
+                        local node_name=$1
+                        ros2-cli.ros2 node list | grep -q "/$node_name"
+                        if [ $? -eq 0 ]; then
+                            echo "$node_name is running."
+                        else
+                            echo "Error - $node_name is not running."
+                            exit 1
+                        fi
+                    }
+                    check_topic() {
+                        local topic_name=$1
+                        local pub_count=$(ros2-cli.ros2 topic info /$topic_name | grep "Publisher count:" | awk '{print $3}')
+                        local sub_count=$(ros2-cli.ros2 topic info /$topic_name | grep "Subscription count:" | awk '{print $3}')
+                        if [ "$pub_count" -gt 0 ] && [ "$sub_count" -gt 0 ]; then
+                            echo "$topic_name has publishers and subscribers."
+                        else
+                            echo "Error - $topic_name has no publishers or subscribers."
+                            exit 1
+                        fi
+                    }
 
-                    timeout 10s ros2-talker-listener &
+                    timeout 3s ros2-talker-listener &
                     check_node listener &
                     check_node talker &
-                    check_topic chatter\n
-                    wait\n
-                    echo "All checks passed successfully."\n
+                    check_topic chatter
+                    wait
+                    echo "All checks passed successfully."

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -16,36 +16,36 @@ jobs:
     with:
       branch-name: main
       snap-name: ros2-talker-listener
-      test-script: "#!/bin/bash
+      test-script: |
+                    #!/bin/bash\n
+                    sudo snap install ros2-cli --channel=foxy/beta\n
+                    wait\n
 
-sudo snap install ros2-cli --channel=foxy/beta
+                    check_node() {\n
+                        local node_name=$1\n
+                        ros2-cli.ros2 node list | grep -q "/$node_name"\n
+                        if [ $? -eq 0 ]; then\n
+                            echo "$node_name is running."\n
+                        else\n
+                            echo "Error - $node_name is not running."\n
+                            exit 1\n
+                        fi\n
+                    }\n
+                    check_topic() {\n
+                        local topic_name=$1\n
+                        local pub_count=$(ros2-cli.ros2 topic info /$topic_name | grep "Publisher count:" | awk '{print $3}')\n
+                        local sub_count=$(ros2-cli.ros2 topic info /$topic_name | grep "Subscription count:" | awk '{print $3}')\n
+                        if [ "$pub_count" -gt 0 ] && [ "$sub_count" -gt 0 ]; then\n
+                            echo "$topic_name has publishers and subscribers."\n
+                        else\n
+                            echo "Error - $topic_name has no publishers or subscribers."\n
+                            exit 1\n
+                        fi\n
+                    }\n
 
-check_node() {
-    local node_name=$1
-    ros2-cli.ros2 node list | grep -q \"/$node_name\"
-    if [ $? -eq 0 ]; then
-        echo \"$node_name is running.\"
-    else
-        echo \"Error - $node_name is not running.\"
-        exit 1
-    fi
-}
-
-check_topic() {
-    local topic_name=$1
-    local pub_count=$(ros2-cli.ros2 topic info /$topic_name | grep \"Publisher count:\" | awk '{print $3}')
-    local sub_count=$(ros2-cli.ros2 topic info /$topic_name | grep \"Subscription count:\" | awk '{print $3}')
-
-    if [ \"$pub_count\" -gt 0 ] && [ \"$sub_count\" -gt 0 ]; then
-        echo \"$topic_name has publishers and subscribers.\"
-    else
-        echo \"Error - $topic_name has no publishers or subscribers.\"
-        exit 1
-    fi
-}
-
-check_node listener
-check_node talker
-check_topic chatter
-
-echo \"All checks passed successfully.\""
+                    timeout 10s ros2-talker-listener &
+                    check_node listener &
+                    check_node talker &
+                    check_topic chatter\n
+                    wait\n
+                    echo "All checks passed successfully."\n

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -43,7 +43,7 @@ jobs:
                         fi
                     }
 
-                    timeout 3s ros2-talker-listener &
+                    timeout 5s ros2-talker-listener &
                     check_node listener &
                     check_node talker &
                     check_topic chatter

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -16,6 +16,7 @@ jobs:
     with:
       branch-name: main
       snap-name: ros2-talker-listener
+      snap-install-args: --devmode
       test-script: |
                     #!/bin/bash
                     sudo snap install ros2-cli --channel=foxy/beta

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -12,7 +12,38 @@ on:
 
 jobs:
   main-snap:
-    uses: ubuntu-robotics/snap_workflows/.github/workflows/build-install-test-snap.yaml@main
+    uses: ubuntu-robotics/snap_workflows/.github/workflows/build-install-test-snap.yaml@F_add_custom_script
     with:
       branch-name: main
       snap-name: ros2-talker-listener
+      test-script: "#!/bin/bash
+
+check_node() {
+    local node_name=$1
+    ros2 node list | grep -q \"/$node_name\"
+    if [ $? -eq 0 ]; then
+        echo \"$node_name is running.\"
+    else
+        echo \"Error: $node_name is not running.\"
+        exit 1
+    fi
+}
+
+check_topic() {
+    local topic_name=$1
+    local pub_count=$(ros2 topic info /$topic_name | grep \"Publisher count:\" | awk '{print $3}')
+    local sub_count=$(ros2 topic info /$topic_name | grep \"Subscription count:\" | awk '{print $3}')
+
+    if [ \"$pub_count\" -gt 0 ] && [ \"$sub_count\" -gt 0 ]; then
+        echo \"$topic_name has publishers and subscribers.\"
+    else
+        echo \"Error: $topic_name has no publishers or subscribers.\"
+        exit 1
+    fi
+}
+
+check_node listener
+check_node talker
+check_topic chatter
+
+echo \"All checks passed successfully.\""

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -19,4 +19,3 @@ apps:
   ros2-talker-listener:
     command: opt/ros/foxy/bin/ros2 launch demo_nodes_cpp talker_listener.launch.py
     extensions: [ros2-foxy]
-


### PR DESCRIPTION
Add bash script that checks that the ros2-talker-listener snap is running as expected. This uses the ros2-cli snap to run commands such as ros2 topic list and ros2 node list. The script is passed to the snap_workflow template as a string, this functionality is added in https://github.com/ubuntu-robotics/snap_workflows/pull/7